### PR TITLE
Control fig size with attribute list plugin and caption using caption blocks

### DIFF
--- a/docs/edit-this-wiki.md
+++ b/docs/edit-this-wiki.md
@@ -22,13 +22,7 @@ Editing the content of the wiki is simple. To do it correctly you need to know a
 
 Now, if you click the button for "Edit this page" on any page on the wiki, you'll be taken to the corresponding markdown file in the repository on github.
 
-<!-- <figure markdown="span">
-    ![Image title]({{ picture_path }}/edit_page_screen.png){ width="300" }
-    <img src="{{ picture_path }}/edit_page_screen.png" alt="Edit this page screenshot" width="500">
-    <figcaption>The "Edit this page" button - top right of every page on this wiki.</figcaption>
-</figure> -->
-
-![Image title]({{ picture_path }}/edit_page_screen.png){ width="500" }
+![Edit this page screenshot]({{ picture_path }}/edit_page_screen.png){ width="500" }
 /// caption
 The "Edit this page" button - top right of every page on this wiki.
 ///

--- a/docs/edit-this-wiki.md
+++ b/docs/edit-this-wiki.md
@@ -22,23 +22,31 @@ Editing the content of the wiki is simple. To do it correctly you need to know a
 
 Now, if you click the button for "Edit this page" on any page on the wiki, you'll be taken to the corresponding markdown file in the repository on github.
 
-<figure style="text-align: center;">
+<!-- <figure markdown="span">
+    ![Image title]({{ picture_path }}/edit_page_screen.png){ width="300" }
     <img src="{{ picture_path }}/edit_page_screen.png" alt="Edit this page screenshot" width="500">
     <figcaption>The "Edit this page" button - top right of every page on this wiki.</figcaption>
-</figure>
+</figure> -->
+
+![Image title]({{ picture_path }}/edit_page_screen.png){ width="500" }
+/// caption
+The "Edit this page" button - top right of every page on this wiki.
+///
 
 Here, you can click the pen to "Edit this file on github", assuming you are logged in.
 
-<figure style="text-align: center;">
-    <img src="{{ picture_path }}/edit_githubmd_screen.png" alt="Edit this page" width="500">
-    <figcaption>Edit this file on github.</figcaption>
-</figure>
+![Edit this page]({{ picture_path }}/edit_githubmd_screen.png){ width="500" }
+/// caption
+Edit this file on github.
+///
+
+
 
 You can now make your changes. When you are done, to avoid conflicts from people modifying the same document, you can not save your changes and have them published directly. Instead, you propose the change and create a ticket for an admin of the wiki to review and approve. In git-nomencalture you will **commit** your changes to a new version of the repository (called a **branch**) and create a request to have your changes pulled in to repository by an admin of the wiki.
 
-<figure style="text-align: center;">
-    <img src="{{ picture_path }}/commit_screenshot.png" alt="Screenshot commit" width="500">
-    <figcaption><b>1.</b> Commit your changes and <b>2.</b> Write a commit message and propose changes in new branch.</figcaption>
-</figure>
+![Screenshot commit]({{ picture_path }}/commit_screenshot.png){ width="500" }
+/// caption
+(1) Commit your changes and. (2) Write a commit message and propose changes in new branch.
+///
 
 To be continued..

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ theme:
       - navigation.footer
       # - navigation.sections # Makes top level sections expandable
 markdown_extensions:
+  - attr_list
   - sane_lists
   - pymdownx.betterem:
       smart_enable: all
@@ -63,6 +64,7 @@ markdown_extensions:
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower
+  - pymdownx.blocks.caption
 validation:
   links:
     absolute_links: relative_to_docs


### PR DESCRIPTION
This pull request includes changes to improve the documentation and configuration of the wiki. The most important changes include updating the image handling in the markdown files and adding new markdown extensions in the `mkdocs.yml` configuration file.

Documentation improvements:

* [`docs/edit-this-wiki.md`](diffhunk://#diff-ae04462e759506740842056eac5e09475ce75b048bc7ef978f037f0fc682024cL25-R50): Updated the image handling by replacing `<figure>` tags with markdown image syntax and adding captions directly after the images.

Configuration updates:

* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R52): Added the `attr_list` extension to the `markdown_extensions` section to enable attribute lists in markdown.
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R67): Added the `pymdownx.blocks.caption` extension to the `markdown_extensions` section to support captions for block elements.