### PR TITLE
Update 01_Mounting.md

### DIFF
--- a/docs/bmic/01_getting_started/01_Mounting.md
+++ b/docs/bmic/01_getting_started/01_Mounting.md
@@ -29,9 +29,11 @@ title: Mounting Network Drives
       * This is the file server for software
     
     * **matlab:** Map \\\\193.10.16.204\\matlab to another drive name (typically X:)
-      * This is the file server for MATLAB scripts
+      * This is the file server for MATLAB scripts, including Solena
       
 7. When prompted for username and password, enter your full KI email adddress and password respectively
+
+Note: some projects use a projects folder (P:) to store data. To gain access to a project folder, connect using the KI instructions for [Windows](https://selfservice.ki.se/en-us/knowledgebase/article/KA-01095) or [Mac](https://selfservice.ki.se/en-US/knowledgebase/article/KA-01096) and request access in [IDAC](https://idac.ki.se/home). 
     
 ## Linux (Debian/Ubuntu)
 


### PR DESCRIPTION
No sure if it is necessary, but added project folders to file pathing 

Added that Solena is located on the matlab script server (not on the file server for software), since users interested in using Solena don't need to map Fluor18. I'm a bit confused by the description of Fluor18 as the file server for software, but I don't think I have ever used the Fluor18 server, even though I do have it mapped. 