### PR TITLE
Added code copying functionality

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ theme:
       - navigation.indexes
       - toc.follow
       - navigation.footer
+      - content.code.copy
       # - navigation.sections # Makes top level sections expandable
 markdown_extensions:
   - attr_list


### PR DESCRIPTION
When there's code in a code block, users can now just click on the copy button to copy it, rather than having to highlight the whole thing.